### PR TITLE
INS-399: Suppress spotbugs errors thrown in Java 11+ which are invalid

### DIFF
--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -24,4 +24,14 @@
         <Source name="~.*\.groovy" />
         <Bug pattern="SE_NO_SERIALVERSIONID" />
     </Match>
+
+    <!-- false positive in Java 11, see https://github.com/spotbugs/spotbugs/issues/756 -->
+    <Match>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE"/>
+    </Match>
+
+    <!-- false positive in Java 11, see https://github.com/spotbugs/spotbugs/issues/756 -->
+    <Match>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
+    </Match>
 </FindBugsFilter>


### PR DESCRIPTION
Suppress false positive error checks in Java 11. See https://github.com/spotbugs/spotbugs/issues/756