### PR TITLE
INS-399: Skip loading ErrorProne in the test case due to dynamic load…

### DIFF
--- a/src/main/groovy/com/brightsparklabs/gradle/baseline/BaselinePlugin.groovy
+++ b/src/main/groovy/com/brightsparklabs/gradle/baseline/BaselinePlugin.groovy
@@ -33,16 +33,15 @@ public class BaselinePlugin implements Plugin<Project> {
         setupVulnerabilityDependencyChecks(project)
 
         /*
-            ErrorProne cannot be loaded dynamically in our test case due to a class-loading exception
-            The exception with the missing class is:
-                java.lang.NoClassDefFoundError: org/gradle/kotlin/dsl/ConfigurationExtensionsKt
-            This needs to be loaded via the `afterEvaluate` phase of Gradle, as it needs to be
-            loaded via `dependences.errorprone` which is only available after loading the plugin.
-            With the way our test-cases run, we try to load the plugins dynamically which is
-            incompatible with loading the dependency via `afterEvaluate`.
-
-            Therefore we disable this plugin from being loaded *specifically* in the test case.
-        */
+         ErrorProne cannot be loaded dynamically in our test case due to a class-loading exception
+         The exception with the missing class is:
+         java.lang.NoClassDefFoundError: org/gradle/kotlin/dsl/ConfigurationExtensionsKt
+         This needs to be loaded via the `afterEvaluate` phase of Gradle, as it needs to be
+         loaded via `dependences.errorprone` which is only available after loading the plugin.
+         With the way our test-cases run, we try to load the plugins dynamically which is
+         incompatible with loading the dependency via `afterEvaluate`.
+         Therefore we disable this plugin from being loaded *specifically* in the test case.
+         */
         if (! project.getName().equals(TEST_PROJECT_NAME)) {
             setupCodeQuality(project)
         }

--- a/src/test/groovy/com/brightsparklabs/gradle/baseline/BaselinePluginTest.groovy
+++ b/src/test/groovy/com/brightsparklabs/gradle/baseline/BaselinePluginTest.groovy
@@ -15,9 +15,10 @@ import spock.lang.Specification
  * Unit tests for {@link BaselinePlugin}.
  */
 public class BaselinePluginTest extends Specification {
+
     def "plugin registers task"() {
         given:
-        def project = ProjectBuilder.builder().build()
+        def project = ProjectBuilder.builder().withName(BaselinePlugin.TEST_PROJECT_NAME).build()
 
         when:
         project.plugins.apply("com.brightsparklabs.gradle.baseline")


### PR DESCRIPTION
We need to specifically prevent loading ErrorProne in our test case, as it cannot be dynamically loaded due to class loading issues as described in the comment.