### PR TITLE
RAD-109: fixed readme plugin import typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Ignore Gradle project-specific cache directory
 .gradle
+.idea/
 
 # Ignore Gradle build output directory
 build

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Ignore Gradle project-specific cache directory
 .gradle
-.idea/
+.idea
 
 # Ignore Gradle build output directory
 build

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Applies brightSPARK Labs standardisation to gradle projects.
 // file: build.gradle
 
 plugins {
-    id 'com.brightsparklabs.gradle.baseline' version: '<version>'
+    id 'com.brightsparklabs.gradle.baseline' version '<version>'
 }
 ```
 


### PR DESCRIPTION
- Changed readme file because of incorrect syntax for importing a plugin
- Added .idea/ to our gitignore file so that IntelliJ specific files weren't included in the repository 