### PR TITLE
RAD-111: Export gradle licences

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The following plugins are currently bundled in automatically:
     - `shadowJar` to generate fat jars.
 - [License Report](https://plugins.gradle.org/plugin/com.github.jk1.dependency-license-report) for 
   generating reports about the licenses of dependencies
-    - `generateLicenseReport` to generate fat jars.
+    - `generateLicenseReport` to generate a license report.
 
 ## Licenses
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ The following plugins are currently bundled in automatically:
 - [Shadow](https://plugins.gradle.org/plugin/com.github.johnrengelman.shadow) plugin
   enables the creation of fat jars.
     - `shadowJar` to generate fat jars.
+- [License Report](https://plugins.gradle.org/plugin/com.github.jk1.dependency-license-report) for 
+  generating reports about the licenses of dependencies
+    - `generateLicenseReport` to generate fat jars.
 
 ## Licenses
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ The following plugins are currently bundled in automatically:
 - [OWASP](https://plugins.gradle.org/plugin/org.owasp.dependencycheck) plugin
   for vulnerability dependency checks.
     - `dependencyCheckAnalyze` to check for vulnerabilities.
+- [Shadow](https://plugins.gradle.org/plugin/com.github.johnrengelman.shadow) plugin
+  for enabling the creation of fat jars.
+    - `shadowJar` to generate fat jar.
 
 ## Licenses
 

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,9 @@ plugins {
 
     // Apply the shadow plugin to build fat jars
     id "com.github.johnrengelman.shadow" version "5.2.0"
+
+    // Apply dependency licence report plugin
+    id "com.github.jk1.dependency-license-report" version "1.13"
 }
 
 // -----------------------------------------------------------------------------
@@ -68,6 +71,7 @@ dependencies {
             "se.patrikerdes:gradle-use-latest-versions-plugin:0.2.13",
             "org.owasp:dependency-check-gradle:5.3.2.1",
             "com.github.johnrengelman.shadow:com.github.johnrengelman.shadow.gradle.plugin:5.2.0",
+            "com.github.jk1:gradle-license-report:1.13"
             )
 
     // Use the awesome Spock testing and specification framework

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ plugins {
     id "com.github.johnrengelman.shadow" version "5.2.0"
 
     // Apply dependency licence report plugin
-    id "com.github.jk1.dependency-license-report" version "1.13"
+    id "com.github.jk1.dependency-license-report" version "1.14"
 }
 
 // -----------------------------------------------------------------------------
@@ -71,7 +71,7 @@ dependencies {
             "se.patrikerdes:gradle-use-latest-versions-plugin:0.2.13",
             "org.owasp:dependency-check-gradle:5.3.2.1",
             "com.github.johnrengelman.shadow:com.github.johnrengelman.shadow.gradle.plugin:5.2.0",
-            "com.github.jk1:gradle-license-report:1.13"
+            "com.github.jk1:gradle-license-report:1.14"
             )
 
     // Use the awesome Spock testing and specification framework

--- a/src/main/groovy/com/brightsparklabs/gradle/baseline/BaselinePlugin.groovy
+++ b/src/main/groovy/com/brightsparklabs/gradle/baseline/BaselinePlugin.groovy
@@ -32,7 +32,7 @@ public class BaselinePlugin implements Plugin<Project> {
         setupStaleDependencyChecks(project)
         setupVulnerabilityDependencyChecks(project)
         setupShadowJar(project)
-        setupDependencyLicenceReport(project)
+        setupDependencyLicenseReport(project)
 
         /*
          ErrorProne cannot be loaded dynamically in our test case due to a class-loading exception
@@ -133,7 +133,7 @@ public class BaselinePlugin implements Plugin<Project> {
         project.plugins.apply "com.github.johnrengelman.shadow"
     }
 
-    private void setupDependencyLicenceReport(final Project project) {
+    private void setupDependencyLicenseReport(final Project project) {
         project.plugins.apply "com.github.jk1.dependency-license-report"
     }
 }

--- a/src/main/groovy/com/brightsparklabs/gradle/baseline/BaselinePlugin.groovy
+++ b/src/main/groovy/com/brightsparklabs/gradle/baseline/BaselinePlugin.groovy
@@ -32,6 +32,7 @@ public class BaselinePlugin implements Plugin<Project> {
         setupStaleDependencyChecks(project)
         setupVulnerabilityDependencyChecks(project)
         setupShadowJar(project)
+        setupDependencyLicenceReport(project)
 
         /*
          ErrorProne cannot be loaded dynamically in our test case due to a class-loading exception
@@ -130,5 +131,9 @@ public class BaselinePlugin implements Plugin<Project> {
     private void setupShadowJar(final Project project) {
         project.plugins.apply "java"
         project.plugins.apply "com.github.johnrengelman.shadow"
+    }
+
+    private void setupDependencyLicenceReport(final Project project) {
+        project.plugins.apply "com.github.jk1.dependency-license-report"
     }
 }

--- a/src/test/groovy/com/brightsparklabs/gradle/baseline/BaselinePluginTest.groovy
+++ b/src/test/groovy/com/brightsparklabs/gradle/baseline/BaselinePluginTest.groovy
@@ -35,5 +35,7 @@ public class BaselinePluginTest extends Specification {
         project.tasks.findByName("useLatestVersions") != null
         // shadow
         project.tasks.findByName("shadowJar") != null
+        // licence report
+        project.tasks.findByName("generateLicenseReport") != null
     }
 }


### PR DESCRIPTION
Added the [Gradle License Report](https://github.com/jk1/Gradle-License-Report) plugin so that we can generate licence reports

resolves #4 