### PR TITLE
Use sensible defaults for versions check.

### DIFF
--- a/src/main/groovy/com/brightsparklabs/gradle/baseline/BaselinePlugin.groovy
+++ b/src/main/groovy/com/brightsparklabs/gradle/baseline/BaselinePlugin.groovy
@@ -171,14 +171,11 @@ public class BaselinePlugin implements Plugin<Project> {
         project.plugins.apply "com.github.ben-manes.versions"
 
         def isUnstable = { String version ->
-            /*
-             * Versions are deemed unstable if the version string
-             * contains a pre-release flag.
-             */
+            // Versions are deemed unstable if the version string contains a pre-release flag.
             return version ==~ /(?i).*-(alpha|beta|rc|cr|m|pre|).*/
         }
 
-        // Only use new dependencies versions if they are a stable release
+        // Only use new dependencies versions if they are a stable release.
         project.tasks.named("dependencyUpdates").configure {
             rejectVersionIf {
                 isUnstable(it.candidate.version)

--- a/src/main/groovy/com/brightsparklabs/gradle/baseline/BaselinePlugin.groovy
+++ b/src/main/groovy/com/brightsparklabs/gradle/baseline/BaselinePlugin.groovy
@@ -170,19 +170,21 @@ public class BaselinePlugin implements Plugin<Project> {
     private void setupStaleDependencyChecks(final Project project) {
         project.plugins.apply "com.github.ben-manes.versions"
 
-        def isUnStable = { String version -> 
-            return ['alpha', 'beta', 'rc', 'cr', 'm'].any { qualifier ->
-                version ==~ /(?i).*[.-]${qualifier}[.\d-]*/
-            }
+        def isUnstable = { String version ->
+            /*
+             * Versions are deemed unstable if the version string
+             * contains a pre-release flag.
+             */
+            return version ==~ /(?i).*-(alpha|beta|rc|cr|m|pre|).*/
         }
-        
+
         // Only use new dependencies versions if they are a stable release
         project.tasks.named("dependencyUpdates").configure {
             rejectVersionIf {
-                isUnStable(it.candidate.version)
+                isUnstable(it.candidate.version)
             }
         }
-        
+
         addTaskAlias(project, project.dependencyUpdates)
 
         project.plugins.apply "se.patrikerdes.use-latest-versions"

--- a/src/main/groovy/com/brightsparklabs/gradle/baseline/BaselinePlugin.groovy
+++ b/src/main/groovy/com/brightsparklabs/gradle/baseline/BaselinePlugin.groovy
@@ -169,6 +169,20 @@ public class BaselinePlugin implements Plugin<Project> {
 
     private void setupStaleDependencyChecks(final Project project) {
         project.plugins.apply "com.github.ben-manes.versions"
+
+        def isUnStable = { String version -> 
+            return ['alpha', 'beta', 'rc', 'cr', 'm'].any { qualifier ->
+                version ==~ /(?i).*[.-]${qualifier}[.\d-]*/
+            }
+        }
+        
+        // Only use new dependencies versions if they are a stable release
+        project.tasks.named("dependencyUpdates").configure {
+            rejectVersionIf {
+                isUnStable(it.candidate.version)
+            }
+        }
+        
         addTaskAlias(project, project.dependencyUpdates)
 
         project.plugins.apply "se.patrikerdes.use-latest-versions"


### PR DESCRIPTION
This branch updated the `dependencyUpdates` plugin to reject unstable/preview releases when used by the `useLatestVersionsCheck` task as per GH-#11 . 