### PR TITLE
Add default git hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,15 @@ The Documentation for this JSON Format can be found within the [Licence Report
 Docs](https://github.com/jk1/Gradle-License-Report#allowed-licenses-file).
 
 ### Override File Caching bug
-Due to a bug with the Licence Report plugin ([#182](https://github.com/jk1/Gradle-License-Report/issues/182), [#223](https://github.com/jk1/Gradle-License-Report/issues/223)), the contents of the override file will not be used correctly by the 
-`bslCheckLicense` task unless the contents of `/build/reports/dependency-license/` have been deleted prior to running the task.
+
+Due to a bug with the Licence Report plugin. The contents of the override file will not be 
+used correctly by the `bslCheckLicense` task, unless the contents of `/build/reports/dependency-license/` 
+have been deleted prior to running the task.
+
+The following reported issues are likely related to this bug:
+
+- [#182](https://github.com/jk1/Gradle-License-Report/issues/182)
+- [#223](https://github.com/jk1/Gradle-License-Report/issues/223)
 
 ## Bundled Plugins
 

--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,11 @@ plugins {
     // Apply the shadow plugin to build fat jars
     id "com.github.johnrengelman.shadow" version "7.1.0"
 
-    // Apply dependency licence report plugin
+    // Apply the dependency licence report plugin
     id "com.github.jk1.dependency-license-report" version "2.0"
+
+    // Apply the git hooks plugin for adding default git hooks
+    id "com.github.jakemarsden.git-hooks" version "0.0.2"
 }
 
 // -----------------------------------------------------------------------------
@@ -179,4 +182,12 @@ spotless {
         greclipse()
         indentWithSpaces(4)
     }
+}
+
+// -----------------------------------------------------------------------------
+// git-hooks-plugin
+// -----------------------------------------------------------------------------
+
+gitHooks {
+    hooks = ['pre-commit': 'spotlessCheck']
 }

--- a/src/main/groovy/com/brightsparklabs/gradle/baseline/BaselinePlugin.groovy
+++ b/src/main/groovy/com/brightsparklabs/gradle/baseline/BaselinePlugin.groovy
@@ -163,8 +163,7 @@ public class BaselinePlugin implements Plugin<Project> {
         project.plugins.apply "com.github.jakemarsden.git-hooks"
 
         project.gitHooks {
-            hooks = ['pre-commit': 'spotlessApply']
-            hooksDirectory = new File("${project.projectDir}/.git/hooks")
+            hooks = ['pre-commit': 'spotlessCheck']
         }
     }
 


### PR DESCRIPTION
As per GH-#10 this branch uses https://github.com/jakemarsden/git-hooks-gradle-plugin to add to default git-hooks to the baseline. By default a `pre-commit` hook is created to run the `spotlessApply` task.