### PR TITLE
RAD-123: Add dependabot.yml file to enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+- package-ecosystem: gradle
+  directory: /
+  schedule:
+    # Defaults to Monday 5am UTC.
+    interval: weekly
+  open-pull-requests-limit: 20
+  reviewers:
+  - al-jeyapal
+  - michael-lyndon-bsl
+  labels:
+  - dependencies


### PR DESCRIPTION
Adds dependabot.yml to the .github directory to enable dependabot functionality for this repository. Currently the reviewers are assigned to AJ and myself. A new label for dependencies has been added to the repository to mark all dependabot pull requests.

