### PR TITLE
RAD-265: Bumped spotless version to latest. Updated changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The changelog is applicable from version `4.6.0` onwards.
 
 ### Changed
 
+* RAD-265: Bumped spotless version.
+
+
 ### Deprecated
 
 ### Removed

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@
 # `gradle.properties` file (see https://github.com/dependabot/dependabot-core/issues/1618).
 
 [versions]
-pluginVersionSpotless = "8.3.0"
+pluginVersionSpotless = "8.8.0"
 
 pluginVersionErrorprone = "5.1.0"
 #  ___ __  __ ____   ___  ____ _____  _    _   _ _____


### PR DESCRIPTION
Running into some issues on some projects where the spotless will fail as it the eclipse formatter used for groovy doesn’t support groovy 4 or 5 features like enhanced switch statements
```
Snippet251fa74e32874b6195289d1eafdec936.groovy: 130: expecting ':', found '->' @ line 130, column 3.
   } -> {
```


Looking at the spotless changelog, v8.7.0 or higher should resolve it as it bumps the formatter version from 4.35 → 4.39.